### PR TITLE
ellipse dimensions need to be unitless

### DIFF
--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -496,8 +496,8 @@ class Beam(u.Quantity):
         """
         from matplotlib.patches import Ellipse
         return Ellipse((xcen, ycen),
-                       width=self.major.to(u.deg).value / pixscale,
-                       height=self.minor.to(u.deg).value / pixscale,
+                       width=(self.major.to(u.deg) / pixscale).to(u.dimensionless_unscaled).value,
+                       height=(self.minor.to(u.deg) / pixscale).to(u.dimensionless_unscaled).value,
                        angle=self.pa.to(u.deg).value)
 
     def as_kernel(self, pixscale, **kwargs):


### PR DESCRIPTION
otherwise you get errors like:
```
Traceback (most recent call last):
  File "/Users/adam/work/orion/alma_lb/analysis/diskmodel.py", line 232, in <module>
      ax.add_patch(beam_ellipse)
File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/matplotlib/axes/_base.py", line 1778, in add_patch
self._update_patch_limits(p)
File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/matplotlib/axes/_base.py", line 1798, in _update_patch_limits
xys = patch.get_patch_transform().transform(vertices)
File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/matplotlib/patches.py", line 1408, in get_patch_transform
self._recompute_transform()
File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/matplotlib/patches.py", line 1397, in _recompute_transform
.scale(width * 0.5, height * 0.5) \
File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/matplotlib/transforms.py", line 1965, in scale
np.float_)
ValueError: setting an array element with a sequence.
```