### PR TITLE
Fix issue affecting convolution of small beams

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES='Cython'
+        - CONDA_DEPENDENCIES='Cython scipy'
         
         # List other runtime dependencies for the package that are available as
         # pip packages here.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
-language: python
+# We set the language to c because python isn't supported on the MacOS X nodes
+# on Travis. However, the language ends up being irrelevant anyway, since we
+# install Python ourselves using conda.
+language: c
 
-python:
-    - 2.7
-    - 3.4
-    - 3.5
-    - 3.6
+os:
+    - linux
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -23,66 +23,109 @@ addons:
 
 env:
     global:
+
         # The following versions are the 'default' for tests, unless
-        # overidden underneath. They are defined here in order to save having
+        # overridden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION=1.11
-        - ASTROPY_VERSION=2
+        - PYTHON_VERSION=3.6
+        - NUMPY_VERSION=stable
+        - ASTROPY_VERSION=stable
+        - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
+        - EVENT_TYPE='pull_request push'
+
+        
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES='Cython scipy'
+        - CONDA_DEPENDENCIES='Cython'
+        
+        # List other runtime dependencies for the package that are available as
+        # pip packages here.
+        # - PIP_DEPENDENCIES=''
+
+        # Conda packages for affiliated packages are hosted in channel
+        # "astropy" while builds for astropy LTS with recent numpy versions
+        # are in astropy-ci-extras. If your package uses either of these,
+        # add the channels to CONDA_CHANNELS along with any other channels
+        # you want to use.
+        - CONDA_CHANNELS='astropy-ci-extras astropy'
+
+        # If there are matplotlib or other GUI tests, uncomment the following
+        # line to use the X virtual framebuffer.
+        # - SETUP_XVFB=True
+
     matrix:
         # Make sure that egg_info works without dependencies
-        - SETUP_CMD='egg_info'
-        # Try all python versions with the latest numpy
-        - SETUP_CMD='test'
+        - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
 
 matrix:
-    include:
 
-        # Do a coverage test in Python 2.
-        - python: 2.7
+    # Don't wait for allowed failures
+    fast_finish: true
+
+    include:
+        # Try MacOS X
+        - os: osx
+          env: SETUP_CMD='test'
+
+        # Do a coverage test.
+        - os: linux
           env: SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        - python: 3.6
+        - os: linux
           env: SETUP_CMD='build_docs -w'
 
-        # Try Astropy development version
-        - python: 3.5
+        # Now try Astropy dev with the latest Python and LTS with Python 2.7 and 3.x.
+        - os: linux
           env: ASTROPY_VERSION=development
-        - python: 3.6
-          env: ASTROPY_VERSION=development
+               EVENT_TYPE='pull_request push cron'
+        - os: linux
+          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts
+        - os: linux
+          env: ASTROPY_VERSION=lts
 
-        # Test older numpy versions >=1.9
-        - python: 2.7
-          env: NUMPY_VERSION=1.10
-        - python: 2.7
-          env: NUMPY_VERSION=1.9
+        # Try all python versions and Numpy versions. Since we can assume that
+        # the Numpy developers have taken care of testing Numpy with different
+        # versions of Python, we can vary Python and Numpy versions at the same
+        # time.
 
-        # Test newest numpy version, which won't work with python 3.4
-        - python: 2.7
+        - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9
+        - os: linux
+          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.10
+        - os: linux
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
+        - os: linux
           env: NUMPY_VERSION=1.12
-        - python: 3.5
-          env: NUMPY_VERSION=1.12
 
-before_install:
+        # Try numpy pre-release
+        - os: linux
+          env: NUMPY_VERSION=prerelease
+               EVENT_TYPE='pull_request push cron'
 
-    # If there are matplotlib tests, comment these out to
-    # Make sure that interactive matplotlib backends work
-    # - export DISPLAY=:99.0
-    # - sh -e /etc/init.d/xvfb start
+        # Do a PEP8 test with pycodestyle
+        - os: linux
+          env: MAIN_CMD='pycodestyle packagename --count' SETUP_CMD=''
+
+    allow_failures:
+        # Do a PEP8 test with pycodestyle
+        # (allow to fail unless your code completely compliant)
+        - os: linux
+          env: MAIN_CMD='pycodestyle packagename --count' SETUP_CMD=''
 
 install:
 
     # We now use the ci-helpers package to set up our testing environment.
     # This is done by using Miniconda and then using conda and pip to install
     # dependencies. Which dependencies are installed using conda and pip is
-    # determined by the CONDA_DEPDENDENCIES and PIP_DEPENDENCIES variables,
+    # determined by the CONDA_DEPENDENCIES and PIP_DEPENDENCIES variables,
     # which should be space-delimited lists of package names. See the README
     # in https://github.com/astropy/ci-helpers for information about the full
     # list of environment variables that can be used to customize your
@@ -90,9 +133,8 @@ install:
     # in how to install a package, in which case you can have additional
     # commands in the install: section below.
 
-    - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
-    - pip install https://github.com/radio-astro-tools/spectral-cube/archive/master.zip
+    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
+    - source ci-helpers/travis/setup_conda.sh
 
     # As described above, using ci-helpers, you should be able to set up an
     # environment with dependencies installed using conda and pip, but in some
@@ -104,10 +146,9 @@ install:
     # other dependencies.
 
 script:
-   - python setup.py $SETUP_CMD
+   - $MAIN_CMD $SETUP_CMD
 
 after_success:
-    # If coveralls.io is set up for this package, uncomment the line
-    # below and replace "packagename" with the name of your package.
+    # If coveralls.io is set up for this package, uncomment the line below.
     # The coveragerc file may be customized as needed for your package.
-    # - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='packagename/tests/coveragerc'; fi
+    # - if [[ $SETUP_CMD == *coverage* ]]; then coveralls --rcfile='packagename/tests/coveragerc'; fi

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ Create a beam from scratch::
 
 Use a beam for Jy -> K conversion::
 
-    >>> (1*u.Jy).to(u.K, u.brightness_temperature(my_beam, 25*u.GHz))
+    >>> (1*u.Jy).to(u.K, u.brightness_temperature(my_beam, 25*u.GHz)) # doctest: +FLOAT_CMP
     <Quantity 7821.572919292681 K>
 
 Convolve with another beam::

--- a/radio_beam/tests/test_beam.py
+++ b/radio_beam/tests/test_beam.py
@@ -335,3 +335,11 @@ def test_from_aips_issue43():
     aips_hdr = fits.Header.fromtextfile(aips_fname)
     aips_beam_hdr = Beam.from_fits_header(aips_hdr)
     npt.assert_almost_equal(aips_beam_hdr.pa.value, -15.06)
+
+def test_small_beam_convolution():
+    # regression test for #68
+    beam1 = Beam(0.1*u.arcsec, 0.001*u.arcsec, 30*u.deg)
+    beam2 = Beam(0.3*u.arcsec, 0.001*u.arcsec, 120*u.deg)
+    conv = beam1.convolve(beam2)
+
+    np.testing.assert_almost_equal(conv.pa.to(u.deg).value, -60)

--- a/radio_beam/tests/test_beam.py
+++ b/radio_beam/tests/test_beam.py
@@ -338,8 +338,8 @@ def test_from_aips_issue43():
 
 def test_small_beam_convolution():
     # regression test for #68
-    beam1 = Beam(0.1*u.arcsec, 0.001*u.arcsec, 30*u.deg)
-    beam2 = Beam(0.3*u.arcsec, 0.001*u.arcsec, 120*u.deg)
+    beam1 = Beam((0.1*u.arcsec).to(u.deg), (0.00001*u.arcsec).to(u.deg), 30*u.deg)
+    beam2 = Beam((0.3*u.arcsec).to(u.deg), (0.00001*u.arcsec).to(u.deg), 120*u.deg)
     conv = beam1.convolve(beam2)
 
     np.testing.assert_almost_equal(conv.pa.to(u.deg).value, -60)

--- a/radio_beam/utils.py
+++ b/radio_beam/utils.py
@@ -88,7 +88,8 @@ def deconvolve(beam, other, failure_returns_pointlike=False):
         new_major = np.sqrt(0.5 * (s + t))
         new_minor = np.sqrt(0.5 * (s - t))
 
-        if np.isclose((abs(gamma) + abs(alpha - beta)).value, 0):
+        # absolute tolerance needs to be <<1 microarcsec
+        if np.isclose(((abs(gamma) + abs(alpha - beta))**0.5).to(u.arcsec).value, 1e-7):
             new_pa = 0.0
         else:
             new_pa = 0.5 * np.arctan2(-1. * gamma, alpha - beta)
@@ -141,7 +142,7 @@ def convolve(beam, other):
     new_major = np.sqrt(0.5 * (s + t))
     new_minor = np.sqrt(0.5 * (s - t))
     # absolute tolerance needs to be <<1 microarcsec
-    if np.isclose((abs(gamma) + abs(alpha - beta)).value, 0, atol=1e-12):
+    if np.isclose(((abs(gamma) + abs(alpha - beta))**0.5).to(u.arcsec).value, 1e-7):
         new_pa = 0.0 * u.deg
     else:
         new_pa = 0.5 * np.arctan2(-1. * gamma, alpha - beta)

--- a/radio_beam/utils.py
+++ b/radio_beam/utils.py
@@ -73,9 +73,9 @@ def deconvolve(beam, other, failure_returns_pointlike=False):
 
     # To deconvolve, the beam must satisfy:
     # alpha < 0
-    alpha_cond = alpha.value + np.finfo(alpha.dtype).eps < 0
+    alpha_cond = alpha.to(u.arcsec**2).value + np.finfo(alpha.dtype).eps < 0
     # beta < 0
-    beta_cond = beta.value + np.finfo(beta.dtype).eps < 0
+    beta_cond = beta.to(u.arcsec**2).value + np.finfo(beta.dtype).eps < 0
     # s < t
     st_cond = s < t + atol_t
 

--- a/radio_beam/utils.py
+++ b/radio_beam/utils.py
@@ -140,7 +140,8 @@ def convolve(beam, other):
 
     new_major = np.sqrt(0.5 * (s + t))
     new_minor = np.sqrt(0.5 * (s - t))
-    if np.isclose((abs(gamma) + abs(alpha - beta)).value, 0):
+    # absolute tolerance needs to be <<1 microarcsec
+    if np.isclose((abs(gamma) + abs(alpha - beta)).value, 0, atol=1e-12):
         new_pa = 0.0 * u.deg
     else:
         new_pa = 0.5 * np.arctan2(-1. * gamma, alpha - beta)


### PR DESCRIPTION
The tolerance for a certain difference-of-numbers was set to 1e-8 by default, which in deg^2 corresponds to 0.36 arcsec - i.e., a very usable beam size!  This PR makes the tolerance smaller.