### PR TITLE
Check for np.int64 in slice

### DIFF
--- a/radio_beam/multiple_beams.py
+++ b/radio_beam/multiple_beams.py
@@ -114,7 +114,7 @@ class Beams(u.Quantity):
         return self.__getitem__(slice(start, stop, increment))
 
     def __getitem__(self, view):
-        if isinstance(view, int):
+        if isinstance(view, (int, np.int64)):
             return Beam(major=self.major[view],
                         minor=self.minor[view],
                         pa=self.pa[view],

--- a/radio_beam/tests/test_beams.py
+++ b/radio_beam/tests/test_beams.py
@@ -79,6 +79,13 @@ def test_indexing():
     assert beams[3].minor.value == 2
     assert isinstance(beams[4], Beam)
 
+    # Also test int64
+    chan = np.int64(3)
+    assert hasattr(beams[chan], 'major')
+    assert beams[chan].major.value == 2
+    assert beams[chan].minor.value == 2
+    assert isinstance(beams[chan], Beam)
+
     mask = np.array([True, False, True, False, True, True], dtype='bool')
     assert hasattr(beams[mask], 'major')
     assert np.all(beams[mask].major.value == majors[mask].value)


### PR DESCRIPTION
Encountered an issue slicing a `VaryingResolutionSpectralCube` from slicing the `Beams` object with an np.int64 value. Cube slicing in spectral-cube checks already checks for np.int64.