### PR TITLE
Beams minor attribute is set to major attribute when passing list of Beam objects

### DIFF
--- a/radio_beam/multiple_beams.py
+++ b/radio_beam/multiple_beams.py
@@ -47,7 +47,7 @@ class Beams(u.Quantity):
 
         if beams is not None:
             major = [beam.major.to(u.deg).value for beam in beams] * u.deg
-            minor = [beam.major.to(u.deg).value for beam in beams] * u.deg
+            minor = [beam.minor.to(u.deg).value for beam in beams] * u.deg
             pa = [beam.pa.to(u.deg).value for beam in beams] * u.deg
 
         # ... given an area make a round beam assuming it is Gaussian

--- a/radio_beam/tests/test_beams.py
+++ b/radio_beam/tests/test_beams.py
@@ -72,6 +72,10 @@ def test_beams_from_list_of_beam():
 
     assert beams == new_beams
 
+    abeams = asymm_beams_for_tests()[0]
+    new_abeams = Beams(beams=[beam for beam in abeams])
+    assert abeams == new_abeams
+
 
 def test_beams_equality_beams():
 


### PR DESCRIPTION
When passing in a list of `Beam` objects to initialize a `Beams` object, the minor attribute is set to the major attribute. This doesn't appear to be caught by any test so I've added the asymmetrical beams in the appropriate test function.