### PR TITLE
Automate fixing common beam failures

### DIFF
--- a/radio_beam/commonbeam.py
+++ b/radio_beam/commonbeam.py
@@ -477,7 +477,11 @@ def ellipse_edges(beam, npts=300, epsilon=1e-3):
     return pts
 
 
-def common_manybeams_mve(beams, tolerance=1e-4, nsamps=200, epsilon=5e-4):
+def common_manybeams_mve(beams, tolerance=1e-4, nsamps=200,
+                         epsilon=5e-4,
+                         auto_increase_epsilon=True,
+                         max_epsilon=1e-3,
+                         max_iter=10):
     '''
     Calculate a common beam size using the Khachiyan Algorithm to find the
     minimum enclosing ellipse from all beam edges.
@@ -497,6 +501,17 @@ def common_manybeams_mve(beams, tolerance=1e-4, nsamps=200, epsilon=5e-4):
         the common beam can marginally be deconvolved for all beams. Small
         deviations result from the finite sampling of points and the choice
         of the tolerance.
+    auto_increase_epsilon : bool, optional
+        Re-run the algorithm when the solution cannot quite be deconvolved from
+        from all the beams. When `True`, epsilon is slightly increased with
+        each iteration until the common beam can be deconvolved from all beams.
+        Default is `True`.
+    max_epsilon : float, optional
+        Maximum epsilon value that is acceptable. Reached with `max_iter`.
+        Default is `1e-3`.
+    max_iter : int, optional
+        Maximum number of times to increase epsilon to try finding a valid
+        common beam solution.
 
     Returns
     -------
@@ -507,30 +522,52 @@ def common_manybeams_mve(beams, tolerance=1e-4, nsamps=200, epsilon=5e-4):
     if not HAS_SCIPY:
         raise ImportError("common_manybeams_mve requires scipy.optimize.")
 
-    pts = []
+    step = 1
 
-    for beam in beams:
-        pts.append(ellipse_edges(beam, nsamps, epsilon=epsilon))
+    while True:
+        pts = []
 
-    all_pts = np.hstack(pts).T
+        for beam in beams:
+            pts.append(ellipse_edges(beam, nsamps, epsilon=epsilon))
 
-    # Now find the outer edges of the convex hull.
-    hull = ConvexHull(all_pts)
-    edge_pts = all_pts[hull.vertices]
+        all_pts = np.hstack(pts).T
 
-    center, radii, rotation = \
-        getMinVolEllipse(edge_pts, tolerance=tolerance)
+        # Now find the outer edges of the convex hull.
+        hull = ConvexHull(all_pts)
+        edge_pts = all_pts[hull.vertices]
 
-    # The rotation matrix is coming out as:
-    # ((sin theta, cos theta)
-    #  (cos theta, - sin theta))
-    pa = np.arctan2(- rotation[0, 0], rotation[1, 0]) * u.rad
+        center, radii, rotation = \
+            getMinVolEllipse(edge_pts, tolerance=tolerance)
 
-    if pa.value == -np.pi or pa.value == np.pi:
-        pa = 0.0 * u.rad
+        # The rotation matrix is coming out as:
+        # ((sin theta, cos theta)
+        #  (cos theta, - sin theta))
+        pa = np.arctan2(- rotation[0, 0], rotation[1, 0]) * u.rad
 
-    com_beam = Beam(major=radii.max() * u.deg, minor=radii.min() * u.deg,
-                    pa=pa)
+        if pa.value == -np.pi or pa.value == np.pi:
+            pa = 0.0 * u.rad
+
+        com_beam = Beam(major=radii.max() * u.deg, minor=radii.min() * u.deg,
+                        pa=pa)
+
+        # If common beam is just slightly smaller than one of the beams,
+        # we increase epsilon to encourage a solution marginally larger
+        # so all beams can be convolved.
+        if auto_increase_epsilon:
+            if not fits_in_largest(beams, com_beam):
+                # Increase epsilon and run again
+                epsilon += (step + 1) * (max_epsilon - epsilon) / max_iter
+                step += 1
+
+                if step == max_iter + 1:
+                    raise BeamError("Could not increase epsilon to find"
+                                    " common beam.")
+
+                continue
+            else:
+                break
+        else:
+            break
 
     if not fits_in_largest(beams, com_beam):
         raise BeamError("Could not find common beam to deconvolve all beams.")

--- a/radio_beam/multiple_beams.py
+++ b/radio_beam/multiple_beams.py
@@ -1,4 +1,4 @@
-import  six
+
 from astropy import units as u
 from astropy.io import fits
 from astropy import constants

--- a/radio_beam/tests/test_beams.py
+++ b/radio_beam/tests/test_beams.py
@@ -4,13 +4,13 @@ import numpy.testing as npt
 from astropy import units as u
 from astropy.io import fits
 
-import warnings 
+import warnings
 import pytest
 
 from ..multiple_beams import Beams
 from ..beam import Beam
 from ..commonbeam import common_2beams, common_manybeams_mve
-from ..utils import InvalidBeamOperationError
+from ..utils import InvalidBeamOperationError, BeamError
 
 from .test_beam import data_path
 
@@ -593,6 +593,7 @@ def test_catch_common_beam_opt():
     with pytest.raises(NotImplementedError):
         beams.common_beam(method='opt')
 
+
 def test_major_minor_swap():
 
     with pytest.raises(ValueError) as exc:
@@ -601,3 +602,38 @@ def test_major_minor_swap():
                       pa=[30., 60.] * u.deg)
 
     assert "Minor axis greater than major axis." in exc.value.args[0]
+
+
+def test_common_beam_mve_auto_increase_epsilon():
+    '''
+    Here's a case where the default MVE parameters fail.
+    By slowly increasing the epsilon* value, we get a common
+    beam the can be deconvolved correctly over the set.
+
+    * epsilon is the small factor added to the ellipse perimeter
+    radius: radius * (1 + epsilon). The solution is then marginally
+    larger than the true optimal solution, but close enough for
+    effectively all use cases.
+    '''
+
+    major = [8.517199, 8.513563, 8.518497, 8.518434, 8.528561, 8.528236,
+             8.530046, 8.530528, 8.530696, 8.533117] * u.arcsec
+    minor = [5.7432523, 5.7446027, 5.7407207, 5.740814, 5.7331843,
+             5.7356524, 5.7338963, 5.733251, 5.732933, 5.73209] * u.arcsec
+    pa = [-32.942623, -32.931957, -33.07815, -33.07532, -33.187653,
+          -33.175243, -33.167213, -33.167244, -33.170418, -33.180233] * u.deg
+
+    beams = Beams(major=major, minor=minor, pa=pa)
+
+    err_str = 'Could not find common beam to deconvolve all beams.'
+    with pytest.raises(BeamError, match=err_str):
+
+        com_beam = beams.common_beam(method='pts',
+                                     epsilon=1e-4,
+                                     auto_increase_epsilon=False)
+
+    # Should run when epsilon is allowed to increase a bit.
+    com_beam = beams.common_beam(method='pts',
+                                 epsilon=5e-4,
+                                 auto_increase_epsilon=True,
+                                 max_epsilon=1e-3)


### PR DESCRIPTION
We rely on an approximate common beam solver that sometimes fails when the solution is marginally (but within the tolerance) smaller than the true common beam. To encourage the solution to converge to an ellipse just marginally larger (<<1% in area) but can be deconvolved from all beams in the set, we add an `epsilon` to the perimeter points used in the solver. Certain cases still fail when `epsilon` is too small.

This PR allows `epsilon` to iteratively increase up to some set maximum to (hopefully) automate what the user would do when this error comes up.

* [ ] Add explanation to docs.