### PR TITLE
changed ordering of `brightness_temperature` arguments; AstropyDeprec…

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ Create a beam from scratch::
 
 Use a beam for Jy -> K conversion::
 
-    >>> (1*u.Jy).to(u.K, u.brightness_temperature(my_beam, 25*u.GHz)) # doctest: +FLOAT_CMP
+    >>> (1*u.Jy).to(u.K, u.brightness_temperature(25*u.GHz, my_beam)) # doctest: +FLOAT_CMP
     <Quantity 7821.572919292681 K>
 
 Convolve with another beam::


### PR DESCRIPTION
When testing examples from the docs, I received the following warning when computing the Jy/K conversion factor:
```
In [1]: from radio_beam import Beam                                                           

In [2]: import astropy.units as u                                                             

In [3]: mb = Beam(60*u.arcsec)                                                                

In [4]: (1*u.Jy).to(u.K, u.brightness_temperature(mb, 115 * u.GHz))                           
WARNING: AstropyDeprecationWarning: The inputs to `brightness_temperature` have changed. Frequency is now the first input, and angular area is the second, optional input. [astropy.units.equivalencies]
Out[4]: <Quantity 0.0256694 K>

```

I have astropy `4.0.1` installed:
```
In [9]: import astropy                                                                        

In [10]: astropy.__version__                                                                  
Out[10]: '4.0.1'
```

