### PR TITLE
Fix for #83: order of brightness equivalency arguments

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ Create a beam from scratch::
 
 Use a beam for Jy -> K conversion::
 
-    >>> (1*u.Jy).to(u.K, u.brightness_temperature(my_beam, 25*u.GHz)) # doctest: +FLOAT_CMP
+    >>> (1*u.Jy).to(u.K, u.brightness_temperature(25*u.GHz, my_beam)) # doctest: +FLOAT_CMP
     <Quantity 7821.572919292681 K>
 
 Convolve with another beam::


### PR DESCRIPTION
See issue #83 - this fixes the deprecation warning from that.