### PR TITLE
Optimize deconvolve

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,6 @@
 0.3.2 (unreleased)
 ------------------
- - none yet
+ - Optimized the deconvolution operation to avoid extra unit conversions and creation of new `Beam` objects. (https://github.com/radio-astro-tools/radio-beam/pull/87)
 
 0.3.1 (2019-02-20)
 ------------------

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -11,7 +11,7 @@ from astropy.modeling.models import Ellipse2D, Gaussian2D
 from astropy.convolution import Kernel2D
 from astropy.convolution.kernels import _round_up_to_odd_integer
 
-from .utils import deconvolve, convolve, RadioBeamDeprecationWarning
+from .utils import deconvolve_opt, convolve, RadioBeamDeprecationWarning
 
 # Conversion between a twod Gaussian FWHM**2 and effective area
 FWHM_TO_AREA = 2*np.pi/(8*np.log(2))
@@ -383,9 +383,9 @@ class Beam(u.Quantity):
         """
 
         new_major, new_minor, new_pa = \
-            deconvolve(self, other,
-                       failure_returns_pointlike=failure_returns_pointlike)
-        return Beam(major=new_major, minor=new_minor, pa=new_pa)
+            deconvolve_opt(self.to_header_keywords(), other.to_header_keywords(),
+                           failure_returns_pointlike=failure_returns_pointlike)
+        return Beam(major=new_major * u.deg, minor=new_minor * u.deg, pa=new_pa * u.rad)
 
     def __eq__(self, other):
 

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -11,7 +11,7 @@ from astropy.modeling.models import Ellipse2D, Gaussian2D
 from astropy.convolution import Kernel2D
 from astropy.convolution.kernels import _round_up_to_odd_integer
 
-from .utils import deconvolve_opt, convolve, RadioBeamDeprecationWarning
+from .utils import deconvolve, deconvolve_opt, convolve, RadioBeamDeprecationWarning
 
 # Conversion between a twod Gaussian FWHM**2 and effective area
 FWHM_TO_AREA = 2*np.pi/(8*np.log(2))
@@ -384,8 +384,15 @@ class Beam(u.Quantity):
 
         new_major, new_minor, new_pa = \
             deconvolve_opt(self.to_header_keywords(), other.to_header_keywords(),
-                           failure_returns_pointlike=failure_returns_pointlike)
-        return Beam(major=new_major * u.deg, minor=new_minor * u.deg, pa=new_pa * u.rad)
+                           failure_returns_pointlike=True)
+
+        # Keep the units from before
+        new_major = (new_major * u.deg).to(self.major.unit)
+        new_minor = (new_minor * u.deg).to(self.minor.unit)
+        new_pa = (new_pa * u.rad).to(self.pa.unit)
+
+        return Beam(major=new_major, minor=new_minor, pa=new_pa)
+
 
     def __eq__(self, other):
 

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -384,7 +384,7 @@ class Beam(u.Quantity):
 
         new_major, new_minor, new_pa = deconvolve_optimized(self.to_header_keywords(),
                                                             other.to_header_keywords(),
-                                                            failure_returns_pointlike=True)
+                                                            failure_returns_pointlike=failure_returns_pointlike)
 
         # Keep the units from before
         new_major = (new_major * u.deg).to(self.major.unit)

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -11,7 +11,7 @@ from astropy.modeling.models import Ellipse2D, Gaussian2D
 from astropy.convolution import Kernel2D
 from astropy.convolution.kernels import _round_up_to_odd_integer
 
-from .utils import deconvolve, deconvolve_opt, convolve, RadioBeamDeprecationWarning
+from .utils import deconvolve_optimized, convolve, RadioBeamDeprecationWarning
 
 # Conversion between a twod Gaussian FWHM**2 and effective area
 FWHM_TO_AREA = 2*np.pi/(8*np.log(2))
@@ -382,9 +382,9 @@ class Beam(u.Quantity):
             failure_returns_pointlike
         """
 
-        new_major, new_minor, new_pa = \
-            deconvolve_opt(self.to_header_keywords(), other.to_header_keywords(),
-                           failure_returns_pointlike=True)
+        new_major, new_minor, new_pa = deconvolve_optimized(self.to_header_keywords(),
+                                                            other.to_header_keywords(),
+                                                            failure_returns_pointlike=True)
 
         # Keep the units from before
         new_major = (new_major * u.deg).to(self.major.unit)

--- a/radio_beam/commonbeam.py
+++ b/radio_beam/commonbeam.py
@@ -10,7 +10,7 @@ except ImportError:
     HAS_SCIPY = False
 
 from .beam import Beam
-from .utils import BeamError, transform_ellipse, deconvolve_opt
+from .utils import BeamError, transform_ellipse, deconvolve_optimized
 
 __all__ = ['commonbeam', 'common_2beams', 'getMinVolEllipse',
            'common_manybeams_mve']
@@ -357,11 +357,11 @@ def fits_in_largest(beams, large_beam=None):
         if equal:
             continue
 
-        out = deconvolve_opt(large_hdr_keywords,
-                             {'BMAJ': major,
-                              'BMIN': minor,
-                              'BPA': pa},
-                             failure_returns_pointlike=True)
+        out = deconvolve_optimized(large_hdr_keywords,
+                                   {'BMAJ': major,
+                                    'BMIN': minor,
+                                    'BPA': pa},
+                                   failure_returns_pointlike=True)
 
         if np.any([ax == 0. for ax in out[:2]]):
             return False

--- a/radio_beam/commonbeam.py
+++ b/radio_beam/commonbeam.py
@@ -10,7 +10,7 @@ except ImportError:
     HAS_SCIPY = False
 
 from .beam import Beam
-from .utils import BeamError, transform_ellipse
+from .utils import BeamError, transform_ellipse, deconvolve_opt
 
 __all__ = ['commonbeam', 'common_2beams', 'getMinVolEllipse',
            'common_manybeams_mve']
@@ -336,13 +336,37 @@ def fits_in_largest(beams, large_beam=None):
     if large_beam is None:
         large_beam = beams.largest_beam()
 
-    for beam in beams:
-        if large_beam == beam:
-            continue
-        deconv_beam = large_beam.deconvolve(beam,
-                                            failure_returns_pointlike=True)
+    large_hdr_keywords = \
+            {'BMAJ': large_beam.major.to(u.deg).value,
+             'BMIN': large_beam.minor.to(u.deg).value,
+             'BPA': large_beam.pa.to(u.deg).value}
 
-        if not deconv_beam.isfinite:
+    majors = beams.major.to(u.deg).value
+    minors = beams.minor.to(u.deg).value
+    pas = beams.pa.to(u.deg).value
+
+    for i, (major, minor, pa) in enumerate(zip(majors, minors, pas)):
+
+        equal = abs(large_hdr_keywords['BMAJ'] - major) < 1e-12
+        equal = equal & (abs(large_hdr_keywords['BMIN'] - minor) < 1e-12)
+
+        # Check if the beam is circular
+        iscircular = (major - minor) / minor < 1e-6
+
+        # position angle only matters if the beam is asymmetric
+        if not iscircular:
+            equal = equal & (((large_hdr_keywords['BPA'] % np.pi) - (pa % np.pi)) < 1e-12)
+
+        if equal:
+            continue
+
+        out = deconvolve_opt(large_hdr_keywords,
+                             {'BMAJ': major,
+                              'BMIN': minor,
+                              'BPA': pa},
+                             failure_returns_pointlike=True)
+
+        if np.any(out[:2] == 0.):
             return False
 
     return True

--- a/radio_beam/commonbeam.py
+++ b/radio_beam/commonbeam.py
@@ -342,17 +342,23 @@ def fits_in_largest(beams, large_beam=None):
     minors = beams.minor.to(u.deg).value
     pas = beams.pa.to(u.deg).value
 
+    # Catch differences below  << 1 microarsec = 2.8e10
+    # This is the same limit used for checking equal beams in Beam.__eq__
+    atol_limit = 1e-12
+
     for major, minor, pa in zip(majors, minors, pas):
 
-        equal = abs(large_hdr_keywords['BMAJ'] - major) < 1e-12
-        equal = equal and (abs(large_hdr_keywords['BMIN'] - minor) < 1e-12)
+        equal = abs(large_hdr_keywords['BMAJ'] - major) < atol_limit
+        equal = equal and (abs(large_hdr_keywords['BMIN'] - minor) < atol_limit)
 
         # Check if the beam is circular
+        # This checks for fractional changes below 1e-6 between the major and minor.
+        # Same limit used in Beam.__eq__
         iscircular = (major - minor) / minor < 1e-6
 
         # position angle only matters if the beam is asymmetric
         if not iscircular:
-            equal = equal and (abs(((large_hdr_keywords['BPA'] % np.pi) - (pa % np.pi))) < 1e-12)
+            equal = equal and (abs(((large_hdr_keywords['BPA'] % np.pi) - (pa % np.pi))) < atol_limit)
 
         if equal:
             continue

--- a/radio_beam/commonbeam.py
+++ b/radio_beam/commonbeam.py
@@ -336,26 +336,23 @@ def fits_in_largest(beams, large_beam=None):
     if large_beam is None:
         large_beam = beams.largest_beam()
 
-    large_hdr_keywords = \
-            {'BMAJ': large_beam.major.to(u.deg).value,
-             'BMIN': large_beam.minor.to(u.deg).value,
-             'BPA': large_beam.pa.to(u.deg).value}
+    large_hdr_keywords = large_beam.to_header_keywords()
 
     majors = beams.major.to(u.deg).value
     minors = beams.minor.to(u.deg).value
     pas = beams.pa.to(u.deg).value
 
-    for i, (major, minor, pa) in enumerate(zip(majors, minors, pas)):
+    for major, minor, pa in zip(majors, minors, pas):
 
         equal = abs(large_hdr_keywords['BMAJ'] - major) < 1e-12
-        equal = equal & (abs(large_hdr_keywords['BMIN'] - minor) < 1e-12)
+        equal = equal and (abs(large_hdr_keywords['BMIN'] - minor) < 1e-12)
 
         # Check if the beam is circular
         iscircular = (major - minor) / minor < 1e-6
 
         # position angle only matters if the beam is asymmetric
         if not iscircular:
-            equal = equal & (((large_hdr_keywords['BPA'] % np.pi) - (pa % np.pi)) < 1e-12)
+            equal = equal and (abs(((large_hdr_keywords['BPA'] % np.pi) - (pa % np.pi))) < 1e-12)
 
         if equal:
             continue
@@ -366,7 +363,7 @@ def fits_in_largest(beams, large_beam=None):
                               'BPA': pa},
                              failure_returns_pointlike=True)
 
-        if np.any(out[:2] == 0.):
+        if np.any([ax == 0. for ax in out[:2]]):
             return False
 
     return True

--- a/radio_beam/tests/test_beam.py
+++ b/radio_beam/tests/test_beam.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     HAS_CASA = False
 
-from ..utils import RadioBeamDeprecationWarning
+from ..utils import RadioBeamDeprecationWarning, BeamError
 
 
 data_dir = os.path.join(os.path.dirname(__file__), 'data')
@@ -280,7 +280,7 @@ def test_deconv_pointlike(major, minor, pa, return_pointlike):
     else:
         try:
             beam1.deconvolve(beam1, failure_returns_pointlike=False)
-        except ValueError:
+        except BeamError:
             pass
 
 

--- a/radio_beam/utils.py
+++ b/radio_beam/utils.py
@@ -73,12 +73,10 @@ def deconvolve_opt(beamprops1, beamprops2, failure_returns_pointlike=False):
     s = alpha + beta
     t = math.sqrt((alpha - beta)**2 + gamma**2)
 
-    # identify the smallest resolution
-    limit = min([maj1, min1, maj2, min2])
-    limit = 0.1 * limit * limit
-
     # Deal with floating point issues
-    atol_t = np.finfo(np.float64).eps
+    # This matches the arcsec**2 check for deconvolve below
+    # Difference is we keep things in deg^2 here
+    atol_t = np.finfo(np.float64).eps / 3600.**2
 
     # To deconvolve, the beam must satisfy:
     # alpha < 0
@@ -176,6 +174,7 @@ def deconvolve(beam, other, failure_returns_pointlike=False):
 
     # Deal with floating point issues
     atol_t = np.finfo(t.dtype).eps * t.unit
+    print(f"deconvolve atol_t {atol_t}")
 
     # To deconvolve, the beam must satisfy:
     # alpha < 0
@@ -184,6 +183,9 @@ def deconvolve(beam, other, failure_returns_pointlike=False):
     beta_cond = beta.to(u.arcsec**2).value + np.finfo(beta.dtype).eps < 0
     # s < t
     st_cond = s < t + atol_t
+
+    print(f"deconvolve alpha {alpha} beta {beta} s {s} t {t}")
+    print(f"deconvolve alpha {alpha_cond} beta {beta_cond} st {st_cond}")
 
     if alpha_cond or beta_cond or st_cond:
         if failure_returns_pointlike:

--- a/radio_beam/utils.py
+++ b/radio_beam/utils.py
@@ -71,15 +71,14 @@ def deconvolve_opt(beamprops1, beamprops2, failure_returns_pointlike=False):
                  (min2**2 - maj2**2) * math.sin(pa2) * math.cos(pa2))
 
     s = alpha + beta
-    t = np.sqrt((alpha - beta)**2 + gamma**2)
+    t = math.sqrt((alpha - beta)**2 + gamma**2)
 
     # identify the smallest resolution
-    axes = np.array([maj1, min1, maj2, min2])
-    limit = np.min(axes)
+    limit = min([maj1, min1, maj2, min2])
     limit = 0.1 * limit * limit
 
     # Deal with floating point issues
-    atol_t = np.finfo(t.dtype).eps
+    atol_t = np.finfo(np.float64).eps
 
     # To deconvolve, the beam must satisfy:
     # alpha < 0
@@ -100,10 +99,11 @@ def deconvolve_opt(beamprops1, beamprops2, failure_returns_pointlike=False):
         new_minor = math.sqrt(0.5 * (s - t))
 
         # absolute tolerance needs to be <<1 microarcsec
-        if np.isclose(((abs(gamma) + abs(alpha - beta))**0.5), 1e-7):
+        atol = 1e-7 / 3600.
+        if (math.sqrt(abs(gamma) + abs(alpha - beta))) < atol:
             new_pa = 0.0
         else:
-            new_pa = 0.5 * np.arctan2(-1. * gamma, alpha - beta)
+            new_pa = 0.5 * math.atan2(-1. * gamma, alpha - beta)
 
     # In the limiting case, the axes can be zero to within precision
     # Add the precision level onto each axis so a deconvolvable beam


### PR DESCRIPTION
Addresses #86 by adding an optimized deconvolve function that doesn't use `u.Quantity` and avoids extra unit conversions.

I also optimized `utils.fits_in_largest` by avoiding slicing `Beams` and forcing a `Beam.__new__` call each time.