### PR TITLE
Change to setup_python.sh for windows builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: c
 
 # The apt packages below are needed for sphinx builds, which can no longer
 # be installed with sudo apt-get.

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ install:
     # we need to use ci-helpers to set up Python.
     - if [[ $TRAVIS_OS_NAME == osx || $TRAVIS_OS_NAME == windows ]]; then
         git clone git://github.com/astropy/ci-helpers.git;
-        source ci-helpers/travis/setup_conda.sh;
+        source ci-helpers/travis/setup_python.sh;
       fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: c
+language: python
 
 # The apt packages below are needed for sphinx builds, which can no longer
 # be installed with sudo apt-get.

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ indexserver =
 [testenv]
 passenv =
     HOME
+    WINDIR
     DISPLAY
     LC_ALL
     LC_CTYPE


### PR DESCRIPTION
Following astropy, change to setup_python.sh for windows builds: https://github.com/astropy/astropy/blob/master/.travis.yml#L250