### PR TITLE
Add beam area equivalence

### DIFF
--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -506,6 +506,7 @@ class Beam(u.Quantity):
 
         return value.to(u.K, self.jtok_equiv(freq))
 
+    @property
     def beamarea_equiv(self):
         return u.beam_angular_area(self.sr)
 

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -506,6 +506,9 @@ class Beam(u.Quantity):
 
         return value.to(u.K, self.jtok_equiv(freq))
 
+    def beamarea_equiv(self):
+        return u.beam_angular_area(self.sr)
+
     def ellipse_to_plot(self, xcen, ycen, pixscale):
         """
         Return a matplotlib ellipse for plotting

--- a/radio_beam/tests/test_beam.py
+++ b/radio_beam/tests/test_beam.py
@@ -165,8 +165,6 @@ def test_beamarea_equiv():
     major = 0.1 * u.rad
     beam = Beam(major, major, 30 * u.deg)
 
-    freq = 1.42 * u.GHz
-
     conv_factor = u.beam_angular_area(beam.sr)
 
     conv_beam_factor = beam.beamarea_equiv()
@@ -181,6 +179,10 @@ def test_beamarea_equiv():
                              (1 * u.Jy / u.sr).to(u.Jy / u.beam,
                                                   equivalencies=conv_beam_factor))
 
+    # Add a by-hand check
+    value = (1 * u.Jy / u.sr).to(u.Jy / u.beam, equivalencies=conv_factor).value
+    byhand_value = 1 * beam.sr.value
+    npt.assert_allclose(value, byhand_value)
 
 def test_convolution():
 

--- a/radio_beam/tests/test_beam.py
+++ b/radio_beam/tests/test_beam.py
@@ -160,6 +160,27 @@ def test_jtok_equiv():
     assert_quantity_allclose((1 * u.K).to(u.Jy, equivalencies=conv_factor),
                              (1 * u.K).to(u.Jy, equivalencies=conv_beam_factor))
 
+def test_beamarea_equiv():
+
+    major = 0.1 * u.rad
+    beam = Beam(major, major, 30 * u.deg)
+
+    freq = 1.42 * u.GHz
+
+    conv_factor = u.beam_angular_area(beam.sr)
+
+    conv_beam_factor = beam.beamarea_equiv()
+
+    assert_quantity_allclose((1 * u.Jy / u.beam).to(u.Jy / u.sr,
+                                                    equivalencies=conv_factor),
+                             (1 * u.Jy / u.beam).to(u.Jy / u.sr,
+                                                    equivalencies=conv_beam_factor))
+
+    assert_quantity_allclose((1 * u.Jy / u.sr).to(u.Jy / u.beam,
+                                                  equivalencies=conv_factor),
+                             (1 * u.Jy / u.sr).to(u.Jy / u.beam,
+                                                  equivalencies=conv_beam_factor))
+
 
 def test_convolution():
 

--- a/radio_beam/tests/test_beam.py
+++ b/radio_beam/tests/test_beam.py
@@ -167,17 +167,15 @@ def test_beamarea_equiv():
 
     conv_factor = u.beam_angular_area(beam.sr)
 
-    conv_beam_factor = beam.beamarea_equiv()
-
     assert_quantity_allclose((1 * u.Jy / u.beam).to(u.Jy / u.sr,
                                                     equivalencies=conv_factor),
                              (1 * u.Jy / u.beam).to(u.Jy / u.sr,
-                                                    equivalencies=conv_beam_factor))
+                                                    equivalencies=beam.beamarea_equiv))
 
     assert_quantity_allclose((1 * u.Jy / u.sr).to(u.Jy / u.beam,
                                                   equivalencies=conv_factor),
                              (1 * u.Jy / u.sr).to(u.Jy / u.beam,
-                                                  equivalencies=conv_beam_factor))
+                                                  equivalencies=beam.beamarea_equiv))
 
     # Add a by-hand check
     value = (1 * u.Jy / u.sr).to(u.Jy / u.beam, equivalencies=conv_factor).value


### PR DESCRIPTION
Add a wrapper for `astropy.units.beam_angular_area` to enable unit conversion from Jy/beam to Jy/(angular area) (e.g., Jy/sr).

This is in prep. for enabling easier unit conversions in spectral-cube.