### PR TITLE
Simplify finding the common beam of any 2 Beam objects

### DIFF
--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -237,9 +237,27 @@ class Beam(u.Quantity):
             return cls(major=bmaj, minor=bmin, pa=bpa)
 
         elif aipsline is not None:
-            bmaj = float(aipsline.split()[3]) * u.deg
-            bmin = float(aipsline.split()[5]) * u.deg
-            bpa = float(aipsline.split()[7]) * u.deg
+            aipsline_split = aipsline.split()
+
+            # Identify beam values by checking for the position in the split corresponding to
+            # the given keyword.
+            def find_key_in_aips_history(key):
+                line_check = [i for i, str_part in enumerate(aipsline_split) if key in str_part]
+
+                if not len(line_check) == 1:
+                    raise ValueError(f"Unable to find {key} in AIPS history {aipsline}")
+
+                return line_check[0]
+
+            idx_maj = find_key_in_aips_history("BMAJ") + 1
+            bmaj = float(aipsline_split[idx_maj]) * u.deg
+
+            idx_min = find_key_in_aips_history("BMIN") + 1
+            bmin = float(aipsline_split[idx_min]) * u.deg
+
+            idx_pa = find_key_in_aips_history("BPA") + 1
+            bpa = float(aipsline_split[idx_pa]) * u.deg
+
             return cls(major=bmaj, minor=bmin, pa=bpa)
 
         else:

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -63,9 +63,7 @@ class Beam(u.Quantity):
             if major is not None:
                 raise ValueError("Can only specify one of {major,minor,pa} "
                                  "and {area}")
-            if not area.unit.is_equivalent(u.sr):
-                raise ValueError("Area unit should be equivalent to steradian.")
-            rad = np.sqrt(area/(2*np.pi))
+            rad = np.sqrt(area/(2*np.pi)) * u.deg
             major = rad * SIGMA_TO_FWHM
             minor = rad * SIGMA_TO_FWHM
             pa = 0.0 * u.deg

--- a/radio_beam/tests/test_beam.py
+++ b/radio_beam/tests/test_beam.py
@@ -69,15 +69,6 @@ def test_manual():
     man_beam_deg = Beam(0.1*u.deg, 0.1*u.deg, 1.0*u.rad)
     npt.assert_almost_equal(man_beam_deg.value, 3.451589629868801e-06)
 
-def test_manual_area():
-    man_beam_area = (0.5 * u.arcsec) ** 2
-    man_beam_val = Beam(area=man_beam_area)
-    npt.assert_equal(man_beam_area.to(u.sr).value, man_beam_val.sr.value)
-
-    with pytest.raises(ValueError) as exc:
-        Beam(area=2.73*u.K)
-    assert "Area unit should be equivalent to steradian." in exc.value.args[0]
-
 def test_bintable():
 
     beams = np.recarray(4, dtype=[('BMAJ', '>f4'), ('BMIN', '>f4'),

--- a/radio_beam/tests/test_beams.py
+++ b/radio_beam/tests/test_beams.py
@@ -552,6 +552,37 @@ def test_commonbeam_multiple(beams, target_beam):
                         target_beam.pa.value, rtol=1e-3)
 
 
+def test_common2beam_inputs():
+
+    majors = [1.7, 2] * u.arcsec
+    minors = [1.3, 1.5] * u.arcsec
+    pas = [0, 30] * u.deg
+
+    # Given a Beams object
+    beams = Beams(major=majors, minor=minors, pa=pas)
+
+    commonbeam_frombeams = common_2beams(beams)
+
+    # Given as separate Beam objects
+    beam1 = Beam(major=majors[0], minor=minors[0], pa=pas[0])
+    beam2 = Beam(major=majors[1], minor=minors[1], pa=pas[1])
+
+    commonbeam_frombeam = common_2beams(beam1, beam2=beam2)
+    commonbeam_frombeam_rev = common_2beams(beam2, beam2=beam1)
+
+    # These should all be the same
+    assert commonbeam_frombeams == commonbeam_frombeam
+    assert commonbeam_frombeams == commonbeam_frombeam_rev
+
+
+def test_common2beam_failwithnosecondbeam():
+
+    beam1 = Beam(major=1 * u.arcsec, minor=1 * u.arcsec, pa=0 * u.deg)
+
+    with pytest.raises(TypeError):
+        commonbeam_frombeam = common_2beams(beam1, beam2=None)
+
+
 @pytest.mark.parametrize(("beams", "target_beam"), casa_commonbeam_suite())
 def test_commonbeam_methods(beams, target_beam):
 


### PR DESCRIPTION
Addresses #97 

This enables requiring a `radio_beam.Beams` object when comparing any 2 beams.
```
from radio_beam.commonbeam import common_2beams
common_beam = common_2beams(beam1, beam2=beam2)
```
This is potentially useful for finding a common beam between 2 different cubes that both can be convolved to.

