### PR TITLE
Simplify finding the common beam of any 2 Beam objects

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,6 +64,14 @@ Find the smallest common beam for the set (see :ref:`here <com_beam>` for more o
     >>> my_beams.common_beam()  # doctest: +SKIP
     Beam: BMAJ=1.50671729431 arcsec BMIN=1.25695643792 arcsec BPA=6.69089813778 deg
 
+Find the common beam between 2 arbitrary beams::
+
+    >>> mybeam1 = Beam(1.0*u.arcsec, 0.5*u.arcsec, 0*u.deg)
+    >>> mybeam2 = Beam(1.0*u.arcsec, 0.5*u.arcsec, 90*u.deg)
+    >>> mycombeam = mybeam1.commonbeam_with(mybeam2)
+    >>> mycombeam  # doctest: +SKIP
+    Beam: BMAJ=1.0 arcsec BMIN=1.0 arcsec BPA=90.0 deg
+
 Getting started
 ^^^^^^^^^^^^^^^
 

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -11,7 +11,6 @@ from astropy.modeling.models import Ellipse2D, Gaussian2D
 from astropy.convolution import Kernel2D
 from astropy.convolution.kernels import _round_up_to_odd_integer
 
-from .commonbeam import find_commonbeam_between
 from .utils import deconvolve_optimized, convolve, RadioBeamDeprecationWarning
 
 # Conversion between a twod Gaussian FWHM**2 and effective area
@@ -526,6 +525,8 @@ class Beam(u.Quantity):
             The beam to find the common beam with.
 
         '''
+        from .commonbeam import find_commonbeam_between
+
         return find_commonbeam_between(self, other_beam)
 
     def ellipse_to_plot(self, xcen, ycen, pixscale):

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -11,6 +11,7 @@ from astropy.modeling.models import Ellipse2D, Gaussian2D
 from astropy.convolution import Kernel2D
 from astropy.convolution.kernels import _round_up_to_odd_integer
 
+from .commonbeam import find_commonbeam_between
 from .utils import deconvolve_optimized, convolve, RadioBeamDeprecationWarning
 
 # Conversion between a twod Gaussian FWHM**2 and effective area
@@ -511,6 +512,21 @@ class Beam(u.Quantity):
     @property
     def beamarea_equiv(self):
         return u.beam_angular_area(self.sr)
+
+    def commonbeam_with(self, other_beam):
+        '''
+        Solve for the common beam with a given `~radio_beam.Beam`.
+
+        This common beam operation is only valid for a set of 2 beams.
+        For the general case, define a set of beams using `~radio_beam.Beams`.
+
+        Parameters
+        ----------
+        other_beam : radio_beam.Beam
+            The beam to find the common beam with.
+
+        '''
+        return find_commonbeam_between(self, other_beam)
 
     def ellipse_to_plot(self, xcen, ycen, pixscale):
         """

--- a/radio_beam/commonbeam.py
+++ b/radio_beam/commonbeam.py
@@ -13,7 +13,7 @@ from .beam import Beam
 from .utils import BeamError, transform_ellipse, deconvolve_optimized
 
 __all__ = ['commonbeam', 'common_2beams', 'getMinVolEllipse',
-           'common_manybeams_mve', 'find_common_']
+           'common_manybeams_mve', 'find_commonbeam_between']
 
 
 def commonbeam(beams, method='pts', **method_kwargs):

--- a/radio_beam/commonbeam.py
+++ b/radio_beam/commonbeam.py
@@ -13,7 +13,7 @@ from .beam import Beam
 from .utils import BeamError, transform_ellipse, deconvolve_optimized
 
 __all__ = ['commonbeam', 'common_2beams', 'getMinVolEllipse',
-           'common_manybeams_mve', 'find_commonbeam_between']
+           'common_manybeams_mve', 'find_common_']
 
 
 def commonbeam(beams, method='pts', **method_kwargs):
@@ -65,7 +65,7 @@ def common_2beams(beams, check_deconvolution=True):
     if (~beams.isfinite).all():
         raise BeamError("All beams in the object are invalid.")
 
-    return find_commonbeam_between(beams[0], beams[1])
+    return find_commonbeam_between(beams[0], beams[1], check_deconvolution=check_deconvolution)
 
 
 def find_commonbeam_between(beam1, beam2, check_deconvolution=True):

--- a/radio_beam/commonbeam.py
+++ b/radio_beam/commonbeam.py
@@ -13,7 +13,7 @@ from .beam import Beam
 from .utils import BeamError, transform_ellipse, deconvolve_optimized
 
 __all__ = ['commonbeam', 'common_2beams', 'getMinVolEllipse',
-           'common_manybeams_mve']
+           'common_manybeams_mve', 'find_commonbeam_between']
 
 
 def commonbeam(beams, method='pts', **method_kwargs):

--- a/radio_beam/commonbeam.py
+++ b/radio_beam/commonbeam.py
@@ -42,7 +42,6 @@ def commonbeam(beams, method='pts', **method_kwargs):
         else:
             raise ValueError("method must be 'pts' or 'opt'.")
 
-
 def common_2beams(beams, check_deconvolution=True):
     '''
     Find a common beam from a `Beams` object with 2 beams. This
@@ -60,29 +59,60 @@ def common_2beams(beams, check_deconvolution=True):
         The smallest common beam in the set of beams.
     '''
 
-    # This code is based on the implementation in CASA:
-    # https://open-bitbucket.nrao.edu/projects/CASA/repos/casa/browse/code/imageanalysis/ImageAnalysis/CasaImageBeamSet.cc
-
     if beams.size != 2:
         raise BeamError("This method is only valid for two beams.")
 
     if (~beams.isfinite).all():
         raise BeamError("All beams in the object are invalid.")
 
-    large_beam = beams.largest_beam()
+    return find_commonbeam_between(beams[0], beams[1])
+
+
+def find_commonbeam_between(beam1, beam2, check_deconvolution=True):
+    '''
+    Find the common beam between 2 `~radio_beam.Beam` objects.
+
+    This function is based on the CASA implementation `ia.commonbeam` that
+    the solution is valid when comparing 2 beams.
+
+    Parameters
+    ----------
+    beam1 : `~radio_beam.Beam`
+        Beam object.
+    beam2 : `~radio_beam.Beam`
+        Beam object.
+    check_deconvolution : bool, optional
+        Check that the common beam solution can be deconvolved from
+        both input beams.
+
+    Returns
+    -------
+    common_beam : `~radio_beam.Beam`
+        The smallest common beam in the set of beams.
+    '''
+
+    # This code is based on the implementation in CASA:
+    # https://open-bitbucket.nrao.edu/projects/CASA/repos/casa/browse/code/imageanalysis/ImageAnalysis/CasaImageBeamSet.cc
+
+    if not beam1.isfinite or not beam2.isfinite:
+        raise BeamError("At least one beam is invalid.")
+
+    # If equal, the common beam is itself.
+    if beam1 == beam2:
+        return beam1
+
+    if beam1 > beam2:
+        large_beam = beam1
+        small_beam = beam2
+    else:
+        large_beam = beam2
+        small_beam = beam1
+
     large_major = large_beam.major.to(u.arcsec)
     large_minor = large_beam.minor.to(u.arcsec)
 
-    if beams.argmax() == 0:
-        small_beam = beams[1]
-    else:
-        small_beam = beams[0]
     small_major = small_beam.major.to(u.arcsec)
     small_minor = small_beam.minor.to(u.arcsec)
-
-    # Case where they're already equal
-    if small_beam == large_beam:
-        return large_beam
 
     deconv_beam = large_beam.deconvolve(small_beam, failure_returns_pointlike=True)
 

--- a/radio_beam/tests/test_beam.py
+++ b/radio_beam/tests/test_beam.py
@@ -398,3 +398,27 @@ def test_major_minor_swap():
                      pa=30. * u.deg)
 
     assert "Minor axis greater than major axis." in exc.value.args[0]
+
+
+def test_commonbeam_builtin():
+    '''
+    Test the built in common beam for Beam with a 2nd beam.
+
+    This test case should come out to a round common beam of 10 arcsec.
+    '''
+
+    beam1 = Beam(10 * u.arcsec, 8 * u.arcsec, 60 * u.deg)
+
+    beam2 = Beam(10 * u.arcsec, 8 * u.arcsec, 150 * u.deg)
+
+    exp_combeam = Beam(10 * u.arcsec)
+
+    com_beam = beam1.commonbeam_with(beam2)
+
+    assert com_beam == exp_combeam
+
+    # Order should not matter
+    com_beam_rev = beam2.commonbeam_with(beam1)
+
+    assert com_beam_rev == exp_combeam
+    assert com_beam_rev == com_beam

--- a/radio_beam/tests/test_beams.py
+++ b/radio_beam/tests/test_beams.py
@@ -521,8 +521,11 @@ def test_commonbeam_angleoffset(beams, target_beam):
                         rtol=1e-3)
     npt.assert_allclose(common_beam.minor.value, target_beam.minor.value,
                         rtol=1e-3)
-    npt.assert_allclose(common_beam.pa.to(u.deg).value,
-                        target_beam.pa.value, rtol=1e-3)
+
+    # Only check when beam is elliptical. Otherwise PA does not matter.
+    if not common_beam.iscircular:
+        npt.assert_allclose(common_beam.pa.to(u.deg).value,
+                            target_beam.pa.value, rtol=1e-3)
 
 
 def casa_commonbeam_suite_multiple():

--- a/radio_beam/tests/test_beams.py
+++ b/radio_beam/tests/test_beams.py
@@ -9,7 +9,7 @@ import pytest
 
 from ..multiple_beams import Beams
 from ..beam import Beam
-from ..commonbeam import common_2beams, common_manybeams_mve
+from ..commonbeam import common_2beams, common_manybeams_mve, find_commonbeam_between
 from ..utils import InvalidBeamOperationError, BeamError
 
 from .test_beam import data_path
@@ -527,6 +527,28 @@ def test_commonbeam_angleoffset(beams, target_beam):
         npt.assert_allclose(common_beam.pa.to(u.deg).value,
                             target_beam.pa.value, rtol=1e-3)
 
+
+@pytest.mark.parametrize(("beams", "target_beam"), casa_commonbeam_suite())
+def test_find_commonbeam_between(beams, target_beam):
+
+    # https://open-bitbucket.nrao.edu/projects/CASA/repos/casa/browse/code/imageanalysis/ImageAnalysis/test/tCasaImageBeamSet.cc#447
+
+    common_beam = find_commonbeam_between(beams[0], beams[1])
+
+    # Order shouldn't matter
+    common_beam_rev = find_commonbeam_between(beams[1], beams[0])
+
+    assert common_beam == common_beam_rev
+
+    npt.assert_allclose(common_beam.major.value, target_beam.major.value,
+                        rtol=1e-3)
+    npt.assert_allclose(common_beam.minor.value, target_beam.minor.value,
+                        rtol=1e-3)
+
+    # Only check when beam is elliptical. Otherwise PA does not matter.
+    if not common_beam.iscircular:
+        npt.assert_allclose(common_beam.pa.to(u.deg).value,
+                            target_beam.pa.value, rtol=1e-3)
 
 def casa_commonbeam_suite_multiple():
 

--- a/radio_beam/tests/test_beams.py
+++ b/radio_beam/tests/test_beams.py
@@ -546,7 +546,7 @@ def test_find_commonbeam_between(beams, target_beam):
                         rtol=1e-3)
 
     # Only check when beam is elliptical. Otherwise PA does not matter.
-    if not common_beam.iscircular:
+    if not common_beam.iscircular():
         npt.assert_allclose(common_beam.pa.to(u.deg).value,
                             target_beam.pa.value, rtol=1e-3)
 


### PR DESCRIPTION
Addresses #97 and is an updated version initially started in #100.

This PR adds a more general `Beam.commonbeam_between` and `find_commonbeam_between` functions that accepts 2 `Beam`s to find the common beam between them. The previous version `common_2beams` exists and still only accepts a `Beams` object.


The  expected usage is from within `Beam`:
```
common_beam = beam1.commonbeam_with(beam2)
```
This should make it far easier to compare beams from 2 different spectral-line cubes or 2D images and find the common beam that both can be convolved to to match the resolution.