### PR TITLE
Allow a slightly larger PA difference to fix tests

### DIFF
--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -399,7 +399,7 @@ class Beam(u.Quantity):
     def __eq__(self, other):
 
         # Catch floating point issues
-        atol_deg = 1e-12 * u.deg
+        atol_deg = 1e-10 * u.deg
 
         this_pa = self.pa.to(u.deg) % (180.0 * u.deg)
         other_pa = other.pa.to(u.deg) % (180.0 * u.deg)


### PR DESCRIPTION
Failing test cases are extremely small differences in the PA (below ~8 decimal points). Allow the equivalence check to have a moderately larger allowed difference.