### PR TITLE
Fix distutils deprecation with Python 3.12

### DIFF
--- a/radio_beam/conftest.py
+++ b/radio_beam/conftest.py
@@ -4,7 +4,7 @@
 from __future__ import print_function, absolute_import, division
 
 import os
-from distutils.version import LooseVersion
+from setuptools._distutils.version import LooseVersion
 
 # Import casatools and casatasks here if available as they can otherwise
 # cause a segfault if imported later on during tests.


### PR DESCRIPTION
`radio_beam` tests fails  when building in `nixpkgs` with Python 3.12 (see NixOS/nixpkgs#298597). This is due to the use of `distutils`, which is deprecated in Python 3.12. 

This quick fix allows the test to run on Python 3.12.


