### PR TITLE
remove Python2 crumbs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -194,4 +194,4 @@ github_issues_url = 'https://github.com/{0}/issues/'.format(setup_cfg['github_pr
 #         continue
 #     dtype, target = line.split(None, 1)
 #     target = target.strip()
-#     nitpick_ignore.append((dtype, six.u(target)))
+#     nitpick_ignore.append((dtype, str(target)))

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,10 +6,9 @@ Requirements
 
 This package has the following dependencies:
 
-* `Python <http://www.python.org>`_ 3.6 or later (Python 3.x is supported)
+* `Python <http://www.python.org>`_ 3.6 or later
 * `Numpy <http://www.numpy.org>`_ 1.8 or later
 * `Astropy <http://www.astropy.org>`__ 1.0 or later
-* `six <http://pypi.python.org/pypi/six/>`__
 
 Installation
 ------------

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -1,4 +1,3 @@
-import six
 from astropy import units as u
 from astropy.io import fits
 from astropy import constants
@@ -165,7 +164,7 @@ class Beam(u.Quantity):
         # ... given a file try to make a fits header
         # assume a string refers to a filename on disk
         if not isinstance(hdr,fits.Header):
-            if isinstance(hdr, six.string_types):
+            if isinstance(hdr, str):
                 if hdr.lower().endswith(('.fits', '.fits.gz', '.fit',
                                          '.fit.gz', '.fits.Z', '.fit.Z')):
                     hdr = fits.getheader(hdr)

--- a/radio_beam/conftest.py
+++ b/radio_beam/conftest.py
@@ -1,8 +1,6 @@
 # this contains imports plugins that configure py.test for astropy tests.
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
-from __future__ import print_function, absolute_import, division
-
 import os
 from setuptools._distutils.version import LooseVersion
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ packages = find:
 install_requires =
     astropy
     numpy>=1.8.0
-    six
     scipy
 
 [options.extras_require]


### PR DESCRIPTION
python2 support was already broken in places:

> docs/conf.py:from configparser import ConfigParser