### PR TITLE
Astropy 6.1.4 #17096 regression fix

### DIFF
--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -86,7 +86,7 @@ class Beam(u.Quantity):
             major = _set_default_unit("major", major, default_unit, equiv_unit=u.deg)
 
         if pa is not None:
-            pa = _set_default_unit("pa", pa, default_unit, equiv_unit=u.deg)
+            pa = _set_default_unit("pa", pa, u.deg, equiv_unit=u.deg)
         else:
             pa = 0 * u.deg
 

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -81,20 +81,23 @@ class Beam(u.Quantity):
             minor = rad * SIGMA_TO_FWHM
             pa = 0.0 * u.deg
 
-        else:
-            # give specified values priority
-
+        # give specified values priority
+        if major is not None:
             major = _set_default_unit("major", major, default_unit, equiv_unit=u.deg)
+
+        if pa is not None:
             pa = _set_default_unit("pa", pa, default_unit, equiv_unit=u.deg)
+        else:
+            pa = 0 * u.deg
 
-            # some sensible defaults
-            if minor is None:
-                minor = major
-            else:
-                minor = _set_default_unit("minor", minor, default_unit, equiv_unit=u.deg)
+        # some sensible defaults
+        if minor is None:
+            minor = major
+        else:
+            minor = _set_default_unit("minor", minor, default_unit, equiv_unit=u.deg)
 
-            if minor > major:
-                raise ValueError("Minor axis greater than major axis.")
+        if minor > major:
+            raise ValueError("Minor axis greater than major axis.")
 
         self = super(Beam, cls).__new__(cls, _to_area(major,minor).value, u.sr)
         self._major = major

--- a/radio_beam/multiple_beams.py
+++ b/radio_beam/multiple_beams.py
@@ -6,7 +6,7 @@ from astropy import wcs
 import numpy as np
 import warnings
 
-from .beam import Beam, _to_area, SIGMA_TO_FWHM
+from .beam import Beam, _to_area, SIGMA_TO_FWHM, _set_default_unit
 from .commonbeam import commonbeam
 from .utils import InvalidBeamOperationError
 
@@ -30,12 +30,14 @@ class Beams(u.Quantity):
             The FWHM minor axes
         pa : :class:`~astropy.units.Quantity` with angular equivalency
             The beam position angles
-        area : :class:`~astropy.units.Quantity` with steradian equivalency
+        areas : :class:`~astropy.units.Quantity` with steradian equivalency
             The area of the beams.  This is an alternative to specifying the
             major/minor/PA, and will create those values assuming a circular
             Gaussian beam.
         default_unit : :class:`~astropy.units.Unit`
             The unit to impose on major, minor if they are specified as floats
+        meta : dict, optional
+            A dictionary of metadata to include in the header.
         beams : List of :class:`~radio_beam.Beam` objects
             List of individual `Beam` objects. The resulting `Beams` object will
             have major and minor axes in degrees.
@@ -59,33 +61,23 @@ class Beams(u.Quantity):
 
         # give specified values priority
         if major is not None:
-            if u.deg.is_equivalent(major.unit):
-                pass
-            else:
-                warnings.warn("Assuming major axes has been specified in degrees")
-                major = major * u.deg
-        if minor is not None:
-            if u.deg.is_equivalent(minor.unit):
-                pass
-            else:
-                warnings.warn("Assuming minor axes has been specified in degrees")
-                minor = minor * u.deg
+            major = _set_default_unit("major", major, default_unit, equiv_unit=u.deg)
+
+
         if pa is not None:
             if len(pa) != len(major):
                 raise ValueError("Number of position angles must match number of major axis lengths")
-            if u.deg.is_equivalent(pa.unit):
-                pass
-            else:
-                warnings.warn("Assuming position angles has been specified in degrees")
-                pa = pa * u.deg
+            pa = _set_default_unit("pa", pa, u.deg, equiv_unit=u.deg)
         else:
-            pa = np.zeros_like(major.value) * u.deg
+            pa = np.zeros(major.shape) * u.deg
 
         # some sensible defaults
         if minor is None:
             minor = major
         elif len(minor) != len(major):
             raise ValueError("Minor and major axes must have same number of values")
+        else:
+            minor = _set_default_unit("minor", minor, default_unit, equiv_unit=u.deg)
 
         if np.any(minor > major):
             raise ValueError("Minor axis greater than major axis.")


### PR DESCRIPTION
From https://github.com/astropy/astropy/issues/17096: astropy 6.1.4 introduced a bug here due to our use of 
```
u.deg.is_equivalent(pa)
```
when `pa` is a `Quantity` and `pa=0 * u.deg`. The immediate fix is to compare to the unit, not the quantity. (See traceback from @olebole here https://github.com/astropy/astropy/issues/17096#issue-2557500683).