### PR TITLE
Fix Beams.__getitem__ ValueError on length-1 tuple keys

### DIFF
--- a/radio_beam/multiple_beams.py
+++ b/radio_beam/multiple_beams.py
@@ -119,6 +119,12 @@ class Beams(u.Quantity):
         return self.__getitem__(slice(start, stop, increment))
 
     def __getitem__(self, view):
+        # numpy passes a length-1 tuple, e.g. (slice(...),), when indexing
+        # a 1D array via `arr[key]` from within other __getitem__
+        # implementations (see radio-astro-tools/radio-beam#110).
+        if isinstance(view, tuple) and len(view) == 1:
+            view = view[0]
+
         if isinstance(view, (int, np.int64)):
             return Beam(major=self.major[view],
                         minor=self.minor[view],

--- a/radio_beam/tests/test_beams.py
+++ b/radio_beam/tests/test_beams.py
@@ -243,6 +243,18 @@ def test_indexing():
     assert hasattr(beams[mask], 'major')
     assert np.all(beams[mask].major.value == majors[mask].value)
 
+    # Regression test for https://github.com/radio-astro-tools/radio-beam/issues/110
+    # A length-1 tuple key (as numpy passes internally from other
+    # __getitem__ implementations) should behave like the unwrapped key.
+    assert hasattr(beams[(slice(0, 3),)], 'major')
+    assert np.all(beams[(slice(0, 3),)].major.value == majors[:3].value)
+
+    assert hasattr(beams[(3,)], 'major')
+    assert beams[(3,)].major.value == 2
+
+    assert hasattr(beams[(mask,)], 'major')
+    assert np.all(beams[(mask,)].major.value == majors[mask].value)
+
 
 def test_average_beams():
 


### PR DESCRIPTION
## Summary
- `Beams.__getitem__` raised `ValueError: Invalid slice` when indexed with a length-1 tuple key (e.g. `(slice(1919, 1921),)`), which numpy passes internally when indexing is forwarded through another object's `__getitem__` — this is what spectral-cube's `VaryingResolutionOneDSpectrum.__getitem__` does, e.g. via `np.nanmedian`.
- Unwraps a length-1 tuple key to the underlying key before dispatching, matching the workaround suggested in the issue.

Fixes #110

## Test plan
- [x] Added regression cases to `test_indexing` in `radio_beam/tests/test_beams.py` covering tuple-wrapped `slice`, `int`, and boolean-array keys
- [x] `pytest radio_beam/tests/test_beams.py` — 51 passed, 7 xfailed (pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)