### PR TITLE
CI: switch PyPI publishing to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,11 @@ jobs:
     needs: [build_sdist_and_wheel]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/radio-beam
+    permissions:
+      id-token: write  # required for PyPI trusted publishing (OIDC)
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -32,5 +37,4 @@ jobs:
           path: dist
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+          attestations: true


### PR DESCRIPTION
## Summary
- Replace username/password PyPI auth (`secrets.pypi_password`) with PyPI's trusted publisher OIDC flow in `publish.yml`, matching the pattern already used by spectral-cube, pvextractor, and uvcombine.
- Adds `environment: pypi` and `permissions: id-token: write` to the `upload_pypi` job, and enables `attestations: true`.

## Before this can publish successfully
This repo's PyPI project (`radio-beam`) needs a trusted publisher configured on pypi.org:
- Owner: `radio-astro-tools`, repo: `radio_beam`
- Workflow filename: `publish.yml`
- Environment name: `pypi`

Until that's set up on PyPI, tag pushes will fail to publish (falling back would require re-adding the token secret).

## Test plan
- [ ] Confirm the `pypi_password` secret can eventually be removed from repo secrets once this is live
- [ ] Configure the trusted publisher for `radio-beam` on PyPI
- [ ] Verify a tagged release publishes successfully via OIDC